### PR TITLE
fix(cli): degrade output to ASCII instead of aborting on legacy code pages (closes #36)

### DIFF
--- a/packages/cli/src/opencomplai_cli/_encoding.py
+++ b/packages/cli/src/opencomplai_cli/_encoding.py
@@ -1,0 +1,120 @@
+"""ASCII degradation for terminals whose encoding cannot carry our output.
+
+Opencomplai's help text, tables and log lines use a handful of typographic
+characters - the em dash in the ``--help`` banner, the arrows in the scanner
+output, the section sign in regulation references. On a Windows console left
+on its default OEM code page (cp437) those characters are not representable,
+and because ``sys.stdout`` is opened with the strict ``errors`` policy the
+CLI does not merely print ``?``: it dies mid-render with
+
+    UnicodeEncodeError: 'charmap' codec can't encode character '\\u2014'
+
+after having already emitted a partial usage block, and exits 1.
+
+Two fixes that look obvious do not work:
+
+* **Forcing the stream to UTF-8.** The console still *decodes* using its own
+  code page, so a UTF-8 em dash arrives as a three-character mojibake run.
+  That is worse than ``?`` - it is wrong *and* it hides what went wrong.
+* **Setting ``PYTHONUTF8`` / ``PYTHONIOENCODING`` at entry.** Both are read
+  during interpreter start-up, long before any of our code is imported, so
+  setting them from inside the process cannot affect the already-created
+  ``sys.stdout``.
+
+Instead we register a codec error handler that transliterates the characters
+we actually emit down to ASCII, and attach it to stdout/stderr only when the
+stream's encoding cannot represent them. On a UTF-8 terminal - the common
+case, and every Linux/macOS run - nothing is touched and the real glyphs are
+printed exactly as before.
+"""
+
+from __future__ import annotations
+
+import codecs
+from typing import IO, Any
+
+#: Namespaced so we can never collide with a handler another library
+#: registered under a generic name.
+ERROR_HANDLER_NAME = "opencomplai_ascii_fallback"
+
+#: Transliterations for the non-ASCII characters the CLI emits, plus the
+#: typographic neighbours that reach us through user-supplied project names,
+#: paths and regulation text. Anything outside this table still degrades to
+#: ``?``, which is the behaviour a lossy terminal had before this module -
+#: the point is that it no longer aborts the command.
+#:
+#: Keys are written as escapes rather than literal glyphs: several of them
+#: are confusable with ASCII (ruff's RUF001 flags exactly that), and this is
+#: the one place where naming the code point beats reading the glyph.
+ASCII_FALLBACKS = {
+    "\u2014": "-",  # EM DASH, in the --help banner
+    "\u2013": "-",  # EN DASH
+    "\u2192": "->",  # RIGHTWARDS ARROW, scanner output
+    "\u2190": "<-",  # LEFTWARDS ARROW
+    "\u00b7": "*",  # MIDDLE DOT, list separators
+    "\u00a7": "S",  # SECTION SIGN, regulation references
+    "\u2500": "-",  # BOX DRAWINGS LIGHT HORIZONTAL
+    "\u2026": "...",  # HORIZONTAL ELLIPSIS
+    "\u2018": "'",  # LEFT SINGLE QUOTATION MARK
+    "\u2019": "'",  # RIGHT SINGLE QUOTATION MARK
+    "\u201c": '"',  # LEFT DOUBLE QUOTATION MARK
+    "\u201d": '"',  # RIGHT DOUBLE QUOTATION MARK
+    "\u2022": "*",  # BULLET
+    "\u00a0": " ",  # NO-BREAK SPACE
+    "\u2713": "v",  # CHECK MARK
+    "\u2717": "x",  # BALLOT X
+}
+
+
+def _ascii_fallback(error: UnicodeError) -> tuple[str, int]:
+    """Replace an unencodable run with its ASCII transliteration."""
+    if not isinstance(error, UnicodeEncodeError):
+        # This handler is only meaningful for encoding; let decoding errors
+        # surface rather than silently mangling input.
+        raise error
+    chunk = error.object[error.start : error.end]
+    return "".join(ASCII_FALLBACKS.get(ch, "?") for ch in chunk), error.end
+
+
+def encoding_is_lossy(encoding: str | None) -> bool:
+    """Return True if ``encoding`` cannot represent every fallback key.
+
+    Used to decide whether a stream needs the handler at all, so that UTF-8
+    terminals keep their real glyphs.
+    """
+    if not encoding:
+        return False
+    try:
+        "".join(ASCII_FALLBACKS).encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return True
+    return False
+
+
+def install_ascii_fallback(*streams: IO[Any]) -> list[IO[Any]]:
+    """Attach the ASCII fallback handler to each lossy stream.
+
+    Returns the streams that were actually reconfigured, which makes the
+    no-op case straightforward to assert in tests. Safe to call more than
+    once, and safe when ``sys.stdout`` has been replaced by something that
+    is not a :class:`io.TextIOWrapper` - pytest's capture, a ``StringIO``.
+    """
+    codecs.register_error(ERROR_HANDLER_NAME, _ascii_fallback)
+
+    reconfigured: list[IO[Any]] = []
+    for stream in streams:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        if getattr(stream, "errors", None) == ERROR_HANDLER_NAME:
+            continue
+        if not encoding_is_lossy(getattr(stream, "encoding", None)):
+            continue
+        try:
+            reconfigure(errors=ERROR_HANDLER_NAME)
+        except (ValueError, OSError):
+            # A detached or otherwise unreconfigurable stream is not worth
+            # failing the command over - the pre-existing behaviour applies.
+            continue
+        reconfigured.append(stream)
+    return reconfigured

--- a/packages/cli/src/opencomplai_cli/main.py
+++ b/packages/cli/src/opencomplai_cli/main.py
@@ -73,6 +73,7 @@ from opencomplai_cli import (
     SUITE_PACKAGES,
     __version__,
 )
+from opencomplai_cli._encoding import install_ascii_fallback
 
 app = typer.Typer(
     name="opencomplai",
@@ -111,6 +112,11 @@ app.add_typer(sync_app, name="sync")
 app.add_typer(dashboard_app, name="dashboard")
 app.add_typer(keys_app, name="keys")
 app.add_typer(ai_app, name="ai")
+
+# Must run before the first byte is written: on a Windows console left on its
+# default OEM code page, the em dash in the --help banner is unencodable and
+# aborts the command mid-render. See opencomplai_cli._encoding.
+install_ascii_fallback(sys.stdout, sys.stderr)
 
 console = Console()
 err_console = Console(stderr=True)

--- a/packages/cli/tests/test_encoding.py
+++ b/packages/cli/tests/test_encoding.py
@@ -1,0 +1,128 @@
+"""Tests for the ASCII fallback that keeps the CLI alive on legacy code pages.
+
+The regression these guard is not cosmetic: before ``_encoding``, running
+``opencomplai --help`` with ``sys.stdout`` on cp437 - the default OEM code
+page of a Windows console - raised ``UnicodeEncodeError`` part-way through
+rendering the banner and exited 1.
+"""
+
+import io
+import os
+import subprocess
+import sys
+
+import pytest
+from opencomplai_cli._encoding import (
+    ASCII_FALLBACKS,
+    ERROR_HANDLER_NAME,
+    encoding_is_lossy,
+    install_ascii_fallback,
+)
+
+BANNER = "Opencomplai — Open-source AI compliance for a trustworthy future."
+
+
+def _lossy_stream(encoding: str = "cp437") -> io.TextIOWrapper:
+    return io.TextIOWrapper(io.BytesIO(), encoding=encoding, newline="")
+
+
+def test_handler_transliterates_the_characters_the_cli_emits():
+    install_ascii_fallback()  # registers the handler without touching streams
+    text = "em—dash arrow→here section§ref"
+    assert text.encode("cp437", errors=ERROR_HANDLER_NAME) == (
+        b"em-dash arrow->here sectionSref"
+    )
+
+
+def test_handler_falls_back_to_question_mark_for_unknown_characters():
+    install_ascii_fallback()
+    # Not in the table, and not representable in cp437: must degrade rather
+    # than raise, matching what a lossy terminal did before this module.
+    assert "漢字".encode("cp437", errors=ERROR_HANDLER_NAME) == b"??"
+
+
+def test_handler_refuses_to_touch_decode_errors():
+    """Silently mangling *input* would be a much worse bug than mangling output."""
+    install_ascii_fallback()
+    with pytest.raises(UnicodeDecodeError):
+        b"\xff\xfe".decode("utf-8", errors=ERROR_HANDLER_NAME)
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [
+        ("utf-8", False),
+        ("utf-16", False),
+        ("cp437", True),
+        ("cp1252", True),  # has the em dash, but not the arrows
+        ("ascii", True),
+        ("not-a-real-codec", True),
+        (None, False),
+    ],
+)
+def test_encoding_is_lossy(encoding, expected):
+    assert encoding_is_lossy(encoding) is expected
+
+
+def test_install_leaves_utf8_streams_alone():
+    stream = _lossy_stream("utf-8")
+    assert install_ascii_fallback(stream) == []
+    stream.write(BANNER)
+    stream.flush()
+    # The real glyph survives - this is the common case and must not regress.
+    assert "—".encode() in stream.buffer.getvalue()
+
+
+def test_install_reconfigures_a_lossy_stream():
+    stream = _lossy_stream("cp437")
+    assert install_ascii_fallback(stream) == [stream]
+    stream.write(BANNER)
+    stream.flush()
+    assert b"Opencomplai - Open-source" in stream.buffer.getvalue()
+
+
+def test_install_without_the_fix_would_raise():
+    """Control: the same write on an untouched cp437 stream still blows up,
+    proving the test above is exercising the fallback and not some ambient
+    tolerance of the encoding."""
+    stream = _lossy_stream("cp437")
+    with pytest.raises(UnicodeEncodeError):
+        stream.write(BANNER)
+
+
+def test_install_is_idempotent():
+    stream = _lossy_stream("cp437")
+    assert install_ascii_fallback(stream) == [stream]
+    assert install_ascii_fallback(stream) == []
+
+
+def test_install_ignores_streams_that_cannot_be_reconfigured():
+    assert install_ascii_fallback(io.StringIO()) == []
+
+
+def test_every_fallback_is_pure_ascii():
+    for source, replacement in ASCII_FALLBACKS.items():
+        assert replacement.isascii(), f"{source!r} maps to non-ASCII {replacement!r}"
+
+
+def test_help_survives_a_legacy_codepage():
+    """End-to-end: the actual failure from the bug report."""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp437"
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
+    env["COLUMNS"] = "80"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.argv = ['opencomplai', '--help']\n"
+            "from opencomplai_cli.main import app\n"
+            "app()\n",
+        ],
+        capture_output=True,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", errors="replace")
+    assert b"Opencomplai - Open-source AI compliance" in proc.stdout


### PR DESCRIPTION
Closes #36

## The bug is worse than reported

The issue describes the em dash rendering as `?`. On cp437 — the default OEM code page of a Windows console — it is not a rendering problem at all. `sys.stdout` is opened with the strict `errors` policy, so the write *raises*:

```
UnicodeEncodeError: 'charmap' codec can't encode character '—' in position 12: character maps to <undefined>
```

`opencomplai --help` emits a truncated usage block and **exits 1**. Captured on Windows before the fix:

```
returncode: 1
stdout: b'  \r\n Usage: opencomplai [OPTIONS] COMMAND [ARGS]...  \r\n ...'   # stops here
```

Worth noting the two code pages behave differently, which is why the report mentions both: the em dash *is* representable in cp1252 (`0x97`), so cp1252 users see it correctly. cp437 has no em dash at all, and that is where it dies. The arrows (`→`, `←`) and `─` are unencodable in **both**.

## Why neither suggested fix works

- **Force the stream to UTF-8.** The console still *decodes* using its own code page, so the em dash arrives as a multi-character mojibake run. That is wrong *and* it hides what went wrong — strictly worse than `?`.
- **Set `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` at entry.** Both are read during interpreter start-up, long before `opencomplai_cli` is imported. Setting them from inside the process cannot affect the already-created `sys.stdout`. They work only if exported by the user *before* launching.

## What this does instead

Adds `packages/cli/src/opencomplai_cli/_encoding.py`, which registers a codec error handler that transliterates the characters the CLI emits down to ASCII, and attaches it to stdout/stderr **only when the stream's encoding cannot represent them**:

| | before | after |
|---|---|---|
| UTF-8 (Linux, macOS, Windows Terminal) | `Opencomplai — Open-source ...` | unchanged, byte for byte |
| cp1252 | `Opencomplai — Open-source ...` | unchanged |
| cp437 | **`UnicodeEncodeError`, exit 1** | `Opencomplai - Open-source ...`, exit 0 |

Characters outside the table still degrade to `?` — the behaviour a lossy terminal already had. The point is that the command no longer aborts.

The fallback table is evidence-based, not guessed: I inventoried every non-ASCII character in `packages/cli/src` and covered all seven (`—` `→` `·` `§` `─` `…` `←`), plus the typographic neighbours that can reach the CLI through user-supplied project names and paths.

## Verification

Windows 11, Python 3.12, ruff pinned to **0.15.12** to match `uv.lock`.

- `pytest packages/cli`: **176 passed, 1 skipped, 2 failed**.
- The same 2 failures — `test_checker_web_local_serves_and_stops_via_page_button` and `test_fixture_scan_json_includes_eu_ai_scan` — **fail identically on pristine `main`**, so they are a pre-existing baseline, not this change. Happy to open a separate issue if they aren't already known.
- 17 new tests in `packages/cli/tests/test_encoding.py`, all passing. One is a deliberate control: it asserts that writing the banner to an *untouched* cp437 stream still raises `UnicodeEncodeError`, so the test proving the fallback works cannot silently pass for the wrong reason.
- End-to-end test runs the real `--help` in a subprocess under `PYTHONIOENCODING=cp437` and asserts exit 0.
- `ruff check` and `ruff format --check` are clean on both new files.

One thing to flag: `packages/cli/src/opencomplai_cli/main.py` already fails `ruff check` (`I001`, `RUF100`) and `ruff format --check` on pristine `main` with the locked ruff, so `ci-python.yml`'s lint job looks red independently of this PR. I deliberately did **not** reformat that file, since sweeping an unrelated 3,400-line module into an encoding fix would bury the actual change. Say the word and I'll do it in a separate `chore:` PR.

## Note on the CLA

This is my first PR here, so the CLA Assistant will want a signature — I'll sign when it prompts.
