### PR TITLE
docs(getting-started): stop pinning a stale version in installation.md (closes #30)

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -40,7 +40,8 @@ Python 3.11+ is required. Verify with:
 | `opencomplai-cli` | [opencomplai-cli](https://pypi.org/project/opencomplai-cli/) | `pip install opencomplai-cli` | CLI only (pulls in core) |
 | `opencomplai-ai` | [opencomplai-ai](https://pypi.org/project/opencomplai-ai/) | `pip install opencomplai-ai` | Optional `--ai-intent` scan plugin |
 
-Latest release: **0.1.2** on PyPI.
+For the current version, see the [release history on
+PyPI](https://pypi.org/project/opencomplai/#history).
 
 ## Optional extras
 
@@ -105,20 +106,23 @@ the created `.venv`.
 
 ## Verify the installation
 
-The CLI does not expose a `--version` flag. Verify with `--help` (lists the
-available commands) and `pip show` (prints the installed version):
+Verify with `--help` (lists the available commands) and `--version` (prints
+the installed version):
 
 === "macOS / Linux"
     ```bash
     opencomplai --help
-    pip show opencomplai          # Version: 0.1.2
+    opencomplai --version
     ```
 
 === "Windows (PowerShell)"
     ```powershell
     opencomplai --help
-    pip show opencomplai          # Version: 0.1.2
+    opencomplai --version
     ```
+
+`opencomplai version` prints the same string, and `pip show opencomplai`
+still works if you want the full distribution metadata.
 
 A successful `opencomplai --help` lists `init`, `check`, `eval`,
 `validate-manifest`, `risk`, `docs`, `keys`, and more.


### PR DESCRIPTION
Closes #30

## What was stale

The issue points at line 43, but `0.1.2` appeared **three** times in `installation.md`:

| Line | Context |
|---|---|
| 43 | `Latest release: **0.1.2** on PyPI.` |
| 114 | `pip show opencomplai          # Version: 0.1.2` (macOS / Linux tab) |
| 120 | `pip show opencomplai          # Version: 0.1.2` (Windows tab) |

Line 43 is now a link to the [PyPI release history](https://pypi.org/project/opencomplai/#history) rather than a number, which is the "doesn't go stale on every release" option the issue preferred.

## One extra correction

Removing the other two meant rewriting the sentence that introduces them, and that sentence is also wrong:

> The CLI does not expose a `--version` flag.

It does. `main.py` declares a `--version` / `-V` option and a `version` subcommand. Checked against this branch:

```
$ opencomplai --version
opencomplai 0.2.0        # exit 0

$ opencomplai version
opencomplai 0.2.0        # exit 0
```

So the verification steps now use `opencomplai --version` instead of a `pip show` line carrying a hand-maintained version comment — which is what let the number drift in the first place. `pip show` is still mentioned, as the way to get full distribution metadata.

## Scope

Docs only — one file, +9/-5. No code touched, so the pre-existing `packages/cli` test failures and lint state on `main` are unaffected either way.

I did not touch the version *numbers* declared in the package metadata; `--version` reports `0.2.0` from the installed metadata while `packages/cli/pyproject.toml` says `0.3.0`, which looks like a separate release-process question rather than something to settle in a docs PR. Flagging it in case it's news.
