### PR TITLE
docs: add the CONTRIBUTORS.md the contributing guide links to (closes #34)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,30 @@
+# Contributors
+
+Opencomplai is built by its contributors. Thank you to everyone who has
+filed an issue, reviewed a pull request, or shipped a change.
+
+## The list
+
+The authoritative, always-current list is the one GitHub maintains from the
+commit history:
+
+**<https://github.com/Opencomplai/opencomplai/graphs/contributors>**
+
+It is deliberately not duplicated here. A hand-maintained roster goes stale
+the moment someone forgets to update it, and silently omitting a contributor
+is worse than not keeping a second copy at all.
+
+Contributions that never become a commit — issue triage, bug reports,
+documentation review, security disclosures — do not appear in that graph.
+Those are credited in the release notes for the version they landed in.
+
+## Getting listed
+
+Open a pull request and get it merged; the graph picks it up automatically.
+[CONTRIBUTING.md](CONTRIBUTING.md) covers how to set up, branch, sign off
+your commits (DCO), and sign the [CLA](CLA.md).
+
+## Maintainers
+
+Current maintainers are listed in the "Maintainers" section of
+[CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Closes #34

`docs/src/contributing/index.md:474` links to `.../blob/main/CONTRIBUTORS.md` under **Recognition**. That file has never existed in the repo, so the link 404s. It is the only reference to `CONTRIBUTORS.md` anywhere in the tree — I grepped `docs/`, `packages/`, `.github/` and `README.md` to check.

## Why create the file rather than drop the link

The issue offers both. Creating it is the more durable of the two here: #33 proposes deleting or rewriting that docs-site contributing page outright, and a fix that edits line 474 gets thrown away by whichever way #33 lands. Adding the file resolves the 404 regardless, and leaves #33 free to do whatever it wants with the page.

## What's in it

Deliberately not a hand-maintained roster. It points at the [contributors graph](https://github.com/Opencomplai/opencomplai/graphs/contributors), which GitHub generates from commit history, with a note on why a second copy isn't kept: a manual list goes stale the moment someone forgets it, and silently omitting a contributor is worse than not having the duplicate.

It also records that non-commit contributions — triage, bug reports, docs review, security disclosures — are credited in release notes, since they never show up in the graph. That matches what the docs page already claims ("In release notes", "On our website").

Links out to `CONTRIBUTING.md` for the DCO/CLA steps and to `CLA.md`; both files exist, so the relative links resolve.

## Scope

One new file, +30 lines. Nothing else touched, no code, no CI surface.
